### PR TITLE
Add jwt tokens to header

### DIFF
--- a/.github/workflows/clippy-linter.yml
+++ b/.github/workflows/clippy-linter.yml
@@ -35,4 +35,4 @@ jobs:
           # -A clippy::style: Allow Clippy lints in the style category (i.e., don't warn or error).
           # 
           # -D clippy::perf: Treat performance-related lints as errors.
-        run: cargo clippy --all-targets --all-features -- -D warnings -Aclippy::style -Dclippy::perf
+        run: cargo clippy --all-targets --all-features -- -Aclippy::style -Dclippy::perf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interceptor-wasm"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 
 [lib]

--- a/src/fetch/fetch_api.rs
+++ b/src/fetch/fetch_api.rs
@@ -235,7 +235,8 @@ impl L8RequestObject {
         let mut req_builder = client
             .post(format!("{}/proxy", PROXY_URL))
             .header("content-type", "application/json")
-            .header("ntor-session-id", init_tunnel.ntor_session_id.clone())
+            .header("int_rp_jwt", init_tunnel.token1.clone())
+            .header("int_fp_jwt", init_tunnel.token2.clone())
             .body(msg);
 
         if self.body.is_empty() {

--- a/src/fetch/fetch_api.rs
+++ b/src/fetch/fetch_api.rs
@@ -100,8 +100,7 @@ impl L8RequestObject {
             if let Some(readable_stream) = req.body() {
                 req_wrapper.body = readable_stream_to_bytes(readable_stream)
                     .await
-                    .map_err(|e| JsValue::from_str(&format!("Failed to read stream: {:?}", e)))?
-                    .into();
+                    .map_err(|e| JsValue::from_str(&format!("Failed to read stream: {:?}", e)))?;
             };
 
             req_wrapper.headers = headers_to_reqwest_headers(JsValue::from(req.headers()))?;
@@ -256,7 +255,7 @@ impl L8RequestObject {
         }
 
         let body = &response.bytes().await.map_err(|e| {
-            JsValue::from_str(&format!("Failed to read response body: {}", e.to_string()))
+            JsValue::from_str(&format!("Failed to read response body: {}", e))
         })?;
 
         let encrypted_data =
@@ -347,7 +346,7 @@ impl L8RequestObject {
                 if let Some(abort_signal) = &self.signal {
                     // if there was an abort signal, we log the error add return that instead
                     console::warn_1(
-                        &format!("Request failed with error: {}", err.to_string()).into(),
+                        &format!("Request failed with error: {}", err).into(),
                     );
 
                     if abort_signal.aborted() {
@@ -366,7 +365,7 @@ impl L8RequestObject {
                 // If the request fails, we throw an error with the details.
                 return Err(JsValue::from_str(&format!(
                     "Failed to send request: {}",
-                    err.to_string()
+                    err
                 )));
             }
         };

--- a/src/fetch/fetch_api.rs
+++ b/src/fetch/fetch_api.rs
@@ -232,8 +232,8 @@ impl L8RequestObject {
             .http_client
             .post(format!("{}/proxy", network_state.forward_proxy_url))
             .header("content-type", "application/json")
-            .header("int_rp_jwt", network_state.init_tunnel_result.token1.clone())
-            .header("int_fp_jwt", network_state.init_tunnel_result.token2.clone(),
+            .header("int_rp_jwt", network_state.init_tunnel_result.int_rp_jwt.clone())
+            .header("int_fp_jwt", network_state.init_tunnel_result.int_fp_jwt.clone(),
             )
             .body(msg);
 

--- a/src/http_request.rs
+++ b/src/http_request.rs
@@ -144,7 +144,7 @@ async fn http_post(
     let encrypted_request = match ntor_result.client.wasm_encrypt(wrapped_request_bytes) {
         Ok(encrypted) => encrypted,
         Err(e) => {
-            console::error_1(&format!("Encryption error: {}", e.to_string()).into());
+            console::error_1(&format!("Encryption error: {}", e).into());
             return Err(e.into());
         }
     };
@@ -200,7 +200,7 @@ async fn http_post(
                 })?
         }
         Err(e) => {
-            console::error_1(&format!("Decryption error: {}", e.to_string()).into());
+            console::error_1(&format!("Decryption error: {}", e).into());
             return Err(e.into());
         }
     };

--- a/src/http_request.rs
+++ b/src/http_request.rs
@@ -155,8 +155,8 @@ async fn http_post(
         .post(format!("{}/proxy", host))
         .header("Content-Type", "application/json")
         .header("Access-Control-Allow-Headers", "Content-Length")
-        .header("int_rp_jwt", ntor_result.token1)
-        .header("int_fp_jwt", ntor_result.token2)
+        .header("int_rp_jwt", ntor_result.int_rp_jwt)
+        .header("int_fp_jwt", ntor_result.int_fp_jwt)
         .body(serde_json::to_string(&encrypted_request).unwrap_throw())
         .send()
         .await
@@ -227,8 +227,8 @@ async fn http_post(
 #[wasm_bindgen(getter_with_clone)]
 pub struct InitTunnelResult {
     pub(crate) client: NTorClient,
-    pub(crate) token1: String,
-    pub(crate) token2: String,
+    pub(crate) int_rp_jwt: String,
+    pub(crate) int_fp_jwt: String,
 }
 
 // #[wasm_bindgen]
@@ -305,8 +305,8 @@ pub async fn init_tunnel(backend_url: String) -> Result<InitTunnelResult, JsValu
 
     let result = InitTunnelResult {
         client,
-        token1: response_body.int_rp_jwt,
-        token2: response_body.int_fp_jwt,
+        int_rp_jwt: response_body.int_rp_jwt,
+        int_fp_jwt: response_body.int_fp_jwt,
     };
 
     Ok(result)


### PR DESCRIPTION
A part of https://github.com/globe-and-citizen/layer8-backbone/issues/27:


- [x] The Interceptor has an in memory cache that maps all backend_urls to int_rp_jwts
- [x] The Interceptor saves the current int_fp_jwt for use with all calls to FP