### PR TITLE
[ISSUE-25] Interceptor Connection State Management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-futures-core = "0.3.31"
-futures-util = "0.3.31"
 uuid = { version = "1", features = ["js", "v4"] }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.50"
@@ -48,22 +46,11 @@ serde_json = "1.0.140"
 serde-wasm-bindgen = "0.4"
 bytes = "1.10.1"
 js-sys = "0.3.77"
-
-# ntor
-hmac = "0.12"
-sha2 = "0.10"
-curve25519-dalek = "4.1.1"
-x25519-dalek = { version = "^2.0.1", features = ["static_secrets"] }
-getrandom = { version = "0.2", features = ["js"] }
 ntor = { git = "https://github.com/globe-and-citizen/ntor.git", tag = "0.1.0" }
-#ntor = { path = "../ntor" }
-
-aes-gcm = "0.10"
 serde = { version = "1.0.219", features = ["derive"] }
 wasm-streams = "0.4.2"
-serde_bytes = "0.11.17"
 url = "2.5.4"
-
+futures = "0.3.31"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"

--- a/src/fetch/fetch_api.rs
+++ b/src/fetch/fetch_api.rs
@@ -100,8 +100,7 @@ impl L8RequestObject {
             if let Some(readable_stream) = req.body() {
                 req_wrapper.body = readable_stream_to_bytes(readable_stream)
                     .await
-                    .map_err(|e| JsValue::from_str(&format!("Failed to read stream: {:?}", e)))?
-                    .into();
+                    .map_err(|e| JsValue::from_str(&format!("Failed to read stream: {:?}", e)))?;
             };
 
             req_wrapper.headers = headers_to_reqwest_headers(JsValue::from(req.headers()))?;
@@ -256,9 +255,10 @@ impl L8RequestObject {
             )));
         }
 
-        let body = &response.bytes().await.map_err(|e| {
-            JsValue::from_str(&format!("Failed to read response body: {}", e.to_string()))
-        })?;
+        let body = &response
+            .bytes()
+            .await
+            .map_err(|e| JsValue::from_str(&format!("Failed to read response body: {}", e)))?;
 
         let encrypted_data =
             serde_json::from_slice::<WasmEncryptedMessage>(&body).map_err(|e| {
@@ -348,7 +348,7 @@ impl L8RequestObject {
                 if let Some(abort_signal) = &self.signal {
                     // if there was an abort signal, we log the error add return that instead
                     console::warn_1(
-                        &format!("Request failed with error: {}", err.to_string()).into(),
+                        &format!("Request failed with error: {}", err).into(),
                     );
 
                     if abort_signal.aborted() {

--- a/src/fetch/fetch_api.rs
+++ b/src/fetch/fetch_api.rs
@@ -377,6 +377,17 @@ impl L8RequestObject {
     }
 }
 
+pub async fn sleep(delay: i32) {
+    let mut cb = |resolve: js_sys::Function, _: js_sys::Function| {
+        _ = web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, delay);
+    };
+
+    let p = js_sys::Promise::new(&mut cb);
+    wasm_bindgen_futures::JsFuture::from(p).await.unwrap();
+}
+
 /// This API is expected to be a 1:1 mapping of the Fetch API.
 /// Arguments:
 /// - `resource`: The resource to fetch, which can be a string, a URL object or a Request object.
@@ -400,7 +411,8 @@ pub async fn fetch(
                     )
                     .into(),
                 );
-                continue; // Retry the check
+                sleep(100).await; // Wait for 100 milliseconds before retrying
+                continue;
             }
             NetworkReadyState::OPEN => {
                 break;

--- a/src/http_request.rs
+++ b/src/http_request.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Debug;
 use bytes::Bytes;
 use reqwest::header::HeaderMap;
 use wasm_bindgen::{JsValue, UnwrapThrowExt};
@@ -222,11 +223,21 @@ async fn http_post(
     return Ok(be_response);
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[wasm_bindgen(getter_with_clone)]
 pub struct InitTunnelResult {
     pub(crate) client: ntor::client::NTorClient,
     pub(crate) ntor_session_id: String,
+}
+
+impl Debug for InitTunnelResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InitTunnelResult {{ ntor_session_id: {}, client: `not debuggable` }}", // TODO: implement Debug for NTorClient
+            self.ntor_session_id,
+        )
+    }
 }
 
 // #[wasm_bindgen]

--- a/src/http_request.rs
+++ b/src/http_request.rs
@@ -222,7 +222,7 @@ async fn http_post(
     return Ok(be_response);
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[wasm_bindgen(getter_with_clone)]
 pub struct InitTunnelResult {
     pub(crate) client: ntor::client::NTorClient,

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -14,25 +14,31 @@ thread_local! {
     static INIT_EVENT_QUEUE: RefCell<HashMap<String, InitEventItem>>= RefCell::new(HashMap::new());
 }
 
-/// This event queue item is used to store the events that are waiting to be processed.
-/// Design:
-/// 1. An initialization call is queued in the event queue. This allows it to be polled later to make sure the tunnel initialization happened or errored out.
-/// 2. Any calls to the `fetch` API will first check if the tunnel is initialized.
-///    - If it is initialized in the NETWORK_STATE, the call is made.
-///    - If it is not initialized, the initialization call is polled in the INIT_EVENT_QUEUE to check if it is done.
-///    - If the initialization call is done, the fetch call is made.
-///    - If the initialization call is not done, the fetch call waits and retries to poll (after x duration?) until the initialization call is done.
-/// 3. If the initialization call failed in INIT_EVENT_QUEUE, the fetch call will return an error.
+// This event queue item is used to store the events that are waiting to be processed.
+// Design:
+// 1. An initialization call is queued in the event queue. This allows it to be polled later to make sure the tunnel initialization happened or errored out.
+// 2. Any calls to the `fetch` API will first check if the tunnel is initialized.
+//    - If it is initialized in the NETWORK_STATE, the call is made.
+//    - If it is not initialized, the initialization call is polled in the INIT_EVENT_QUEUE to check if it is done.
+//    - If the initialization call is done, the fetch call is made.
+//    - If the initialization call is not done, the fetch call waits and retries to poll (after x duration?) until the initialization call is done.
+// 3. If the initialization call failed in INIT_EVENT_QUEUE, the fetch call will return an error.
 struct InitEventItem {
     init_event: Pin<Box<dyn Future<Output = Result<InitTunnelResult, JsValue>> + 'static>>,
     forward_proxy_url: String,
+    version: Version,
     _dev_flag: Option<bool>,
 }
 
+// This is an alias value to track the version of the tunnel. It is incremented every time a new tunnel is initialized.
+pub(crate) type Version = u16;
+
+#[derive(Debug)]
 pub(crate) struct NetworkState {
     pub http_client: reqwest::Client,
     pub init_tunnel_result: InitTunnelResult,
     pub forward_proxy_url: String,
+    pub version: Version,
     pub _dev_flag: Option<bool>,
 }
 
@@ -61,25 +67,33 @@ pub fn init_encrypted_tunnel(
 ) -> Result<(), JsValue> {
     for service_provider in service_providers {
         let base_url = base_url(&service_provider.url)?;
-
-        // skip if already initialized
-        match NetworkReadyState::ready_state(&base_url)? {
-            NetworkReadyState::OPEN | NetworkReadyState::CONNECTING => {
-                continue;
-            }
-            _ => {}
-        }
-
-        let backend_url = format!("{}/init-tunnel?backend_url={}", forward_proxy_url, base_url);
-        let init_event = InitEventItem {
-            forward_proxy_url: forward_proxy_url.clone(),
-            _dev_flag: _dev_flag,
-            init_event: Box::pin(init_tunnel(backend_url)),
-        };
-
-        INIT_EVENT_QUEUE.with_borrow_mut(|queue| queue.insert(base_url.clone(), init_event));
+        schedule_init_event(&base_url, 1, forward_proxy_url.clone(), _dev_flag)?;
     }
 
+    Ok(())
+}
+
+pub(crate) fn schedule_init_event(
+    base_url: &str,
+    expected_next_version: Version,
+    forward_proxy_url: String,
+    _dev_flag: Option<bool>,
+) -> Result<(), JsValue> {
+    // version is already connecting or connected, return early
+    let current_version = NetworkReadyState::ready_state(base_url)?.version();
+    if current_version >= expected_next_version {
+        return Ok(());
+    }
+
+    let backend_url = format!("{}/init-tunnel?backend_url={}", forward_proxy_url, base_url);
+    let init_event = InitEventItem {
+        forward_proxy_url,
+        version: current_version + 1,
+        _dev_flag,
+        init_event: Box::pin(init_tunnel(backend_url)),
+    };
+
+    INIT_EVENT_QUEUE.with_borrow_mut(|queue| queue.insert(base_url.to_string(), init_event));
     Ok(())
 }
 
@@ -97,107 +111,135 @@ pub fn base_url(url: &str) -> Result<String, JsValue> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum NetworkReadyState {
-    CONNECTING,
-    OPEN,
+pub(crate) enum NetworkReadyState {
+    CONNECTING(Version),
+    OPEN(Version),
     CLOSED,
 }
 
 impl NetworkReadyState {
+    /// This function checks the current state of the network for the given base URL. It will only return the state of the latest version
+    /// if there are multiple versions of the network state.
     pub fn ready_state(base_url: &str) -> Result<NetworkReadyState, JsValue> {
-        if NETWORK_STATE.with_borrow(|cache| cache.get(base_url).is_some()) {
-            return Ok(NetworkReadyState::OPEN);
+        let mut versions = Vec::new();
+        if let Some(version) =
+            NETWORK_STATE.with_borrow(|cache| cache.get(base_url).map(|val| val.version))
+        {
+            versions.push(NetworkReadyState::OPEN(version));
         }
 
-        // confirm if we have an entry in the InitEventQueue, poll if it is ready if not return CONNECTING
-        let state: Option<Result<NetworkReadyState, JsValue>> =
-            INIT_EVENT_QUEUE.with_borrow_mut(|queue| match queue.get_mut(base_url) {
-                Some(fut) => {
-                    let noop_waker = futures::task::noop_waker_ref();
-                    let mut ctx = futures::task::Context::from_waker(&noop_waker);
-
-                    match fut.init_event.poll_unpin(&mut ctx) {
-                        Poll::Ready(val) => match val {
-                            Ok(_) => {
-                                console::log_1(
-                                    &format!(
-                                        "Tunnel initialized successfully for base URL: {}",
-                                        base_url
-                                    )
-                                    .into(),
-                                );
-
-                                // add the result to the cache
-                                let network_state = NetworkState {
-                                    http_client: reqwest::Client::new(),
-                                    init_tunnel_result: val.unwrap(),
-                                    forward_proxy_url: fut.forward_proxy_url.clone(),
-                                    _dev_flag: fut._dev_flag,
-                                };
-
-                                NETWORK_STATE.with_borrow_mut(|cache| {
-                                    cache.insert(base_url.to_string(), Arc::new(network_state));
-                                });
-
-                                Some(Ok(NetworkReadyState::OPEN))
-                            }
-
-                            Err(err) => {
-                                console::error_1(
-                                    &format!(
-                                        "Error initializing tunnel for base URL: {}. Error: {:?}",
-                                        base_url, err
-                                    )
-                                    .into(),
-                                );
-                                Some(Err(err))
-                            }
-                        },
-
-                        Poll::Pending => {
-                            console::log_1(
-                                &format!(
-                                    "Network is still initializing for base URL: {}",
-                                    base_url
-                                )
-                                .into(),
-                            );
-
-                            Some(Ok(NetworkReadyState::CONNECTING))
-                        }
-                    }
-                }
-                None => {
-                    console::log_1(
-                        &format!("Items found in the INIT_EVENT_QUEUE: {:?}", queue.keys()).into(),
-                    );
-                    None
-                }
+        // check if there's a version in the INIT_EVENT_QUEUE
+        let init_queue_item: Option<Result<NetworkReadyState, JsValue>> = INIT_EVENT_QUEUE
+            .with_borrow_mut(|queue| match queue.get_mut(base_url) {
+                Some(fut) => pool_op(base_url, fut),
+                None => None,
             });
 
-        match state {
+        match init_queue_item {
             Some(val) => {
-                let state = val?;
-                if state == NetworkReadyState::OPEN {
+                let state = match val {
+                    Ok(val) => val,
+                    Err(err) => {
+                        // We failed to initialize, we;re popping this item from the queue
+                        INIT_EVENT_QUEUE.with_borrow_mut(|queue| {
+                            queue.remove(base_url);
+                        });
+
+                        return Err(err);
+                    }
+                };
+
+                if let NetworkReadyState::OPEN(..) = state {
                     INIT_EVENT_QUEUE.with_borrow_mut(|queue| {
                         queue.remove(base_url);
                     });
                 }
 
-                Ok(state)
+                versions.push(state);
             }
             None => {
                 // If the base URL is not in the cache or event queue, it means it was never initialized.
                 console::warn_1(
                     &format!(
-                        "No initialization event found for base URL: {}. Assuming it is closed.",
+                        "No init event found for URL: {}. Assuming it is already open.",
                         base_url
                     )
                     .into(),
                 );
 
-                Ok(NetworkReadyState::CLOSED)
+                if versions.is_empty() {
+                    return Ok(NetworkReadyState::CLOSED);
+                }
             }
+        }
+
+        versions.sort_by_key(|a| a.version());
+
+        let latest = versions
+            .last()
+            .cloned()
+            .unwrap_or(NetworkReadyState::CLOSED);
+
+        console::log_1(&format!("URL: {}. Network state version: {:?}", base_url, latest).into());
+
+        Ok(latest)
+    }
+
+    pub fn version(&self) -> Version {
+        match self {
+            NetworkReadyState::CONNECTING(ver) => *ver,
+            NetworkReadyState::OPEN(ver) => *ver,
+            NetworkReadyState::CLOSED => 0, // No version for closed state
+        }
+    }
+}
+
+// This function polls the future returning the result of the tunnel initialization if it is ready.
+fn pool_op(base_url: &str, fut: &mut InitEventItem) -> Option<Result<NetworkReadyState, JsValue>> {
+    let noop_waker = futures::task::noop_waker_ref();
+    let mut ctx = futures::task::Context::from_waker(&noop_waker);
+
+    match fut.init_event.poll_unpin(&mut ctx) {
+        Poll::Ready(val) => match val {
+            Ok(init_tunnel_result) => {
+                console::log_1(
+                    &format!("Tunnel initialized successfully for base URL: {}", base_url).into(),
+                );
+
+                // add the result to the cache
+                let network_state = NetworkState {
+                    http_client: reqwest::Client::new(),
+                    init_tunnel_result,
+                    forward_proxy_url: fut.forward_proxy_url.clone(),
+                    version: fut.version,
+                    _dev_flag: fut._dev_flag,
+                };
+
+                NETWORK_STATE.with_borrow_mut(|cache| {
+                    cache.insert(base_url.to_string(), Arc::new(network_state));
+                });
+
+                Some(Ok(NetworkReadyState::OPEN(fut.version)))
+            }
+
+            Err(err) => {
+                console::error_1(
+                    &format!(
+                        "Error initializing tunnel for base URL: {}. Error: {:?}",
+                        base_url, err
+                    )
+                    .into(),
+                );
+                Some(Err(err))
+            }
+        },
+
+        Poll::Pending => {
+            console::log_1(
+                &format!("Network is still initializing for base URL: {}", base_url).into(),
+            );
+
+            Some(Ok(NetworkReadyState::CONNECTING(fut.version)))
         }
     }
 }

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -1,5 +1,6 @@
-use std::{cell::RefCell, collections::HashMap, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, future::Future, pin::Pin, sync::Arc, task::Poll};
 
+use futures::FutureExt;
 use wasm_bindgen::prelude::*;
 
 use crate::http_request::{InitTunnelResult, init_tunnel};
@@ -9,7 +10,19 @@ thread_local! {
     ///
     /// It maps a provider name (e.g., "https://provider.com") to its corresponding `NetworkState`.
     pub(crate) static NETWORK_STATE: RefCell<HashMap<String, Arc<NetworkState>>> = RefCell::new(HashMap::new());
+    static INIT_EVENT_QUEUE: RefCell<InitEventQueue>= RefCell::new(HashMap::new());
 }
+
+/// This event queue is used to store the events that are waiting to be processed.
+/// Design:
+/// 1. An initialization call is queued in the event queue. This allows it to be polled later to make sure the tunnel initialization happened or errored out.
+/// 2. Any calls to the `fetch` API will first check if the tunnel is initialized.
+///    - If it is initialized in the NETWORK_STATE, the call is made.
+///    - If it is not initialized, the initialization call is polled in the INIT_EVENT_QUEUE to check if it is done.
+///    - If the initialization call is done, the fetch call is made.
+///    - If the initialization call is not done, the fetch call waits and retries to poll (after x duration?) until the initialization call is done.
+/// 3. If the initialization call failed in INIT_EVENT_QUEUE, the fetch call will return an error.
+type InitEventQueue = HashMap<String, Pin<Box<dyn Future<Output = Result<(), JsValue>> + 'static>>>;
 
 #[derive(Debug)]
 pub(crate) struct NetworkState {
@@ -39,35 +52,46 @@ impl ServiceProvider {
 ///
 /// Make sure this call is blocking (**is being awaited**) before making any requests to the service providers.,
 #[wasm_bindgen(js_name = "initEncryptedTunnel")]
-pub async fn init_encrypted_tunnel(
+pub fn init_encrypted_tunnel(
     forward_proxy_url: String,
     service_providers: Vec<ServiceProvider>,
     _dev_flag: Option<bool>,
 ) -> Result<(), JsValue> {
     for service_provider in service_providers {
         let base_url = base_url(&service_provider.url)?;
-        if NETWORK_STATE.with_borrow(|cache| cache.contains_key(&base_url)) {
-            // if the provider is already initialized, skip
-            continue;
+        match NetworkReadyState::ready_state(&base_url)? {
+            NetworkReadyState::OPEN | NetworkReadyState::CONNECTING => {
+                // If the network is connecting, we will handle it in the INIT_EVENT_QUEUE
+                continue;
+            }
+            NetworkReadyState::CLOSED => {}
         }
 
-        let init_tunnel_result = init_tunnel(format!(
-            "{}/init-tunnel?backend_url={}",
-            forward_proxy_url, base_url
-        ))
-        .await?;
+        let init_event: Pin<Box<dyn Future<Output = Result<(), JsValue>> + 'static>> = {
+            let backend_url = format!("{}/init-tunnel?backend_url={}", forward_proxy_url, base_url);
+            let forward_proxy_url = forward_proxy_url.clone();
+            let _dev_flag = _dev_flag.clone();
+            let base_url = base_url.clone();
+            Box::pin(async {
+                let init_tunnel_result = init_tunnel(backend_url).await?;
 
-        let state = NetworkState {
-            http_client: reqwest::Client::new(),
-            init_tunnel_result,
-            forward_proxy_url: forward_proxy_url.clone(),
-            _dev_flag,
+                let state = NetworkState {
+                    http_client: reqwest::Client::new(),
+                    init_tunnel_result,
+                    forward_proxy_url: forward_proxy_url,
+                    _dev_flag: None, // TODO: cloning does not work, find out why
+                };
+
+                // store the result in the NETWORK_STATE
+                NETWORK_STATE.with_borrow_mut(|cache| {
+                    cache.insert(base_url, Arc::new(state));
+                });
+
+                Ok(())
+            })
         };
 
-        // store the result in the NETWORK_STATE
-        NETWORK_STATE.with_borrow_mut(|cache| {
-            cache.insert(base_url, Arc::new(state));
-        });
+        INIT_EVENT_QUEUE.with_borrow_mut(|queue| queue.insert(base_url.clone(), init_event));
     }
 
     Ok(())
@@ -84,4 +108,47 @@ pub fn base_url(url: &str) -> Result<String, JsValue> {
     }
 
     Ok(base_url)
+}
+
+pub enum NetworkReadyState {
+    CONNECTING,
+    OPEN,
+    CLOSED,
+}
+
+impl NetworkReadyState {
+    pub fn ready_state(base_url: &str) -> Result<NetworkReadyState, JsValue> {
+        if NETWORK_STATE.with_borrow(|cache| cache.get(base_url).is_some()) {
+            return Ok(NetworkReadyState::OPEN);
+        }
+
+        // confirm if we have an entry in the InitEventQueue, poll if it is ready if not return CONNECTING
+        let state: Option<Result<NetworkReadyState, JsValue>> =
+            INIT_EVENT_QUEUE.with_borrow_mut(|queue| match queue.get_mut(base_url) {
+                Some(fut) => {
+                    let noop_waker = futures::task::noop_waker();
+                    let mut ctx = futures::task::Context::from_waker(&noop_waker);
+
+                    match fut.poll_unpin(&mut ctx) {
+                        Poll::Ready(val) => match val {
+                            Ok(_) => {
+                                // remove the entry from the queue
+                                queue.remove(base_url);
+                                Some(Ok(NetworkReadyState::OPEN))
+                            }
+
+                            Err(err) => Some(Err(err)),
+                        },
+
+                        Poll::Pending => Some(Ok(NetworkReadyState::CONNECTING)),
+                    }
+                }
+                None => None,
+            });
+
+        match state {
+            Some(val) => Ok(val?),
+            None => Ok(NetworkReadyState::CLOSED), // If the base URL is not in the cache, it means the network is not ready
+        }
+    }
 }

--- a/src/network_state.rs
+++ b/src/network_state.rs
@@ -74,7 +74,7 @@ pub fn init_encrypted_tunnel(
         let backend_url = format!("{}/init-tunnel?backend_url={}", forward_proxy_url, base_url);
         let init_event = InitEventQueue {
             forward_proxy_url: forward_proxy_url.clone(),
-            _dev_flag: _dev_flag.clone(),
+            _dev_flag: _dev_flag,
             init_event: Box::pin(init_tunnel(backend_url)),
         };
 
@@ -133,7 +133,7 @@ impl NetworkReadyState {
                                     http_client: reqwest::Client::new(),
                                     init_tunnel_result: val.unwrap(),
                                     forward_proxy_url: fut.forward_proxy_url.clone(),
-                                    _dev_flag: fut._dev_flag.clone(),
+                                    _dev_flag: fut._dev_flag,
                                 };
 
                                 NETWORK_STATE.with_borrow_mut(|cache| {


### PR DESCRIPTION
Closes: https://github.com/globe-and-citizen/interceptor-refactor/issues/25

Additional changes include:
- removing unused crates that were in Cargo.toml

With the new changes, we won't have to block and can use without `awaiting`
```ts
try {
    let providers = [ServiceProvider.new(backend_url)];
    initEncryptedTunnel(forward_proxy_url, providers);
} catch (err) {
    throw new Error(`Failed to initialize encrypted tunnel: ${err}`);
}
```

Related PR:
- https://github.com/globe-and-citizen/layer8-backbone/pull/44