### PR TITLE
upd: opt release profile for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ name = "interceptor-wasm"
 version = "0.1.14"
 edition = "2024"
 
+[profile.release]
+codegen-units = 1
+opt-level = "z"
+lto = true
+debug = false
+panic = "abort"
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 


### PR DESCRIPTION
Below are the optimizations made for size in this PR

- `727.98 KB`: default: 
- `608.18 KB`: With release profile conf
- ~`**TBA**`: With release profile conf + `no_std`~ wasmbindgen is not compatible with no_std